### PR TITLE
Update the GET parameter for InventoryRepository

### DIFF
--- a/src/Repositories/InventoryRepository.php
+++ b/src/Repositories/InventoryRepository.php
@@ -26,7 +26,7 @@ class InventoryRepository extends BaseRepository
         ?Id $colorIds = null
     ): iterable {
         $uri = uri('inventories', [], [
-            'item_types'  => toString($itemTypes, ItemType::default()),
+            'item_type'  => toString($itemTypes, ItemType::default()),
             'status'      => toString($status, InventoryStatus::default()),
             'category_id' => toString($categoryIds, Id::default()),
             'color_id'    => toString($colorIds, Id::default()),


### PR DESCRIPTION
It's causing error with correct downloading inventory by Type - BrickLink changed this from item_types to item_type